### PR TITLE
Fix previous revert commit not properly merged.

### DIFF
--- a/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
+++ b/ycsb-mongodb/mongodb/src/main/java/com/yahoo/ycsb/db/MongoDbClient.java
@@ -198,23 +198,11 @@ public class MongoDbClient extends DB {
      */
     @Override
     public void cleanup() throws DBException {
-<<<<<<< HEAD
-        if (initCount.decrementAndGet() == 0) {
+        if (initCount.decrementAndGet() <= 0) {
              for (int i=0;i<mongo.length;i++) { 
                 try {
                    mongo[i].close(); 
                } catch (Exception e1) { /* ignore */ }
-=======
-        if (initCount.decrementAndGet() <= 0) {
-            try {
-                for (int i=0;i<mongo.length;i++) mongo[i].close();
-            }
-            catch (Exception e1) {
-                System.err.println("Could not close MongoDB connection pool: "
-                        + e1.toString());
-                e1.printStackTrace();
-                return;
->>>>>>> parent of e73dbf7... fix connection pool size and cleanup code
             }
         }
     }


### PR DESCRIPTION
    Fixes commit 961fcdd, which consisted on a manual merge of a revert not properly applied.

    Leaves the repository state as if previously reverted commit e73dbf7 has never been applied, but commit 3e3ab88 was applied.

    Source code compiles again.